### PR TITLE
Put the thing that's actually changed in the changes hash

### DIFF
--- a/lib/dirty_associations.rb
+++ b/lib/dirty_associations.rb
@@ -14,19 +14,21 @@ module DirtyAssociations
     # The +association+ parameter should be a string or symbol representing the name of an association.
     def monitor_association_changes(association)
       ids = "#{association.to_s.singularize}_ids"
+      attributes = "#{association.to_s}_attributes"
+
       [association, ids].each do |name|
         define_method "#{name}=" do |value|
-          attribute_will_change!(ids)
+          attribute_will_change!(name)
           super(value)
         end
-      end
 
-      define_method "#{ids}_changed?" do
-        changed.include?(ids)
-      end
+        define_method "#{name}_changed?" do
+          changes.has_key?(name.to_s)
+        end
 
-      define_method "#{ids}_previously_changed?" do
-        previous_changes.keys.include?(ids)
+        define_method "#{name}_previously_changed?" do
+          previous_changes.has_key?(name.to_s)
+        end
       end
     end
   end

--- a/test/dirty_associations_test.rb
+++ b/test/dirty_associations_test.rb
@@ -8,7 +8,7 @@ class DirtyAssociationsTest < ActiveSupport::TestCase
 
     bar.foos = [ foo ]
     assert_equal [ foo ], bar.foos
-    assert bar.foo_ids_changed?
+    assert bar.foos_changed?
   end
 
   test "setting has_many association ids adds association to changes" do
@@ -23,23 +23,23 @@ class DirtyAssociationsTest < ActiveSupport::TestCase
 
   test "changes reset by save" do
     bar.foos = [ FactoryGirl.create(:foo) ]
-    assert bar.foo_ids_changed?
+    assert bar.foos_changed?
 
     bar.save
-    refute bar.foo_ids_changed?
+    refute bar.foos_changed?
   end
 
   test "has_many association appears in previous_changes after save" do
-    refute bar.foo_ids_previously_changed?
+    refute bar.foos_previously_changed?
 
     bar.foos = [ FactoryGirl.create(:foo) ]
-    refute bar.foo_ids_previously_changed?
+    refute bar.foos_previously_changed?
 
     bar.save
-    assert bar.foo_ids_previously_changed?
+    assert bar.foos_previously_changed?
 
     bar.save
-    refute bar.foo_ids_previously_changed?
+    refute bar.foos_previously_changed?
   end
 
 private


### PR DESCRIPTION
This change ensures that the thing that was actually changed shows up in the changes hash rather than always showing the "_ids" as having changed.
