### PR TITLE
Track dirty nested attributes

### DIFF
--- a/lib/dirty_associations.rb
+++ b/lib/dirty_associations.rb
@@ -16,7 +16,7 @@ module DirtyAssociations
       ids = "#{association.to_s.singularize}_ids"
       attributes = "#{association.to_s}_attributes"
 
-      [association, ids].each do |name|
+      [association, ids, attributes].each do |name|
         define_method "#{name}=" do |value|
           attribute_will_change!(name)
           super(value)

--- a/test/dirty_associations_test.rb
+++ b/test/dirty_associations_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'byebug'
 
 class DirtyAssociationsTest < ActiveSupport::TestCase
   test "setting has_many association adds object to changes" do
@@ -19,6 +20,11 @@ class DirtyAssociationsTest < ActiveSupport::TestCase
     bar.foo_ids = [ foo.id ]
     assert_equal [ foo.id ], bar.foo_ids
     assert bar.foo_ids_changed?
+  end
+
+  test "setting has_many assocation attributes adds association to changes" do
+    bar.assign_attributes(:foos_attributes => [{}, {}])
+    assert bar.foos_attributes_changed?
   end
 
   test "changes reset by save" do

--- a/test/dummy/app/models/bar.rb
+++ b/test/dummy/app/models/bar.rb
@@ -1,6 +1,9 @@
 class Bar < ActiveRecord::Base
   include DirtyAssociations
 
+  attr_accessor :foos_attributes
+
   has_many :foos
   monitor_association_changes :foos
+  accepts_nested_attributes_for :foos
 end


### PR DESCRIPTION
This allows users of dirty attributes to `monitor_association_changes` made by setting the nested attributes directly.
