### PR TITLE
Dirty nested attributes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    dirty_associations (0.1.0)
-      rails (~> 4.0.1)
+    dirty_associations (0.2.1)
+      rails (>= 3.2.1)
 
 GEM
   remote: https://rubygems.org/
@@ -31,7 +31,7 @@ GEM
       multi_json (~> 1.3)
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
-    arel (4.0.1)
+    arel (4.0.2)
     atomic (1.1.14)
     builder (3.1.4)
     erubis (2.7.0)
@@ -45,10 +45,10 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    mime-types (1.25)
+    mime-types (1.25.1)
     minitest (4.7.5)
     multi_json (1.8.2)
-    polyglot (0.3.3)
+    polyglot (0.3.4)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -66,7 +66,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.1.0)
-    sprockets (2.10.0)
+    sprockets (2.12.1)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)

--- a/lib/dirty_associations.rb
+++ b/lib/dirty_associations.rb
@@ -18,16 +18,16 @@ module DirtyAssociations
 
       [association, ids, attributes].each do |name|
         define_method "#{name}=" do |value|
-          attribute_will_change!(name)
+          attribute_will_change!(association)
           super(value)
         end
 
         define_method "#{name}_changed?" do
-          changes.has_key?(name.to_s)
+          changes.has_key?(association.to_s)
         end
 
         define_method "#{name}_previously_changed?" do
-          previous_changes.has_key?(name.to_s)
+          previous_changes.has_key?(association.to_s)
         end
       end
     end

--- a/test/dirty_associations_test.rb
+++ b/test/dirty_associations_test.rb
@@ -1,11 +1,10 @@
 require 'test_helper'
-require 'byebug'
 
 class DirtyAssociationsTest < ActiveSupport::TestCase
   test "setting has_many association adds object to changes" do
     foo = FactoryGirl.create(:foo)
 
-    refute bar.foo_ids_changed?
+    refute bar.foos_changed?
 
     bar.foos = [ foo ]
     assert_equal [ foo ], bar.foos
@@ -15,16 +14,16 @@ class DirtyAssociationsTest < ActiveSupport::TestCase
   test "setting has_many association ids adds association to changes" do
     foo = FactoryGirl.create(:foo)
 
-    refute bar.foo_ids_changed?
+    refute bar.foos_changed?
 
     bar.foo_ids = [ foo.id ]
     assert_equal [ foo.id ], bar.foo_ids
-    assert bar.foo_ids_changed?
+    assert bar.foos_changed?
   end
 
   test "setting has_many assocation attributes adds association to changes" do
     bar.assign_attributes(:foos_attributes => [{}, {}])
-    assert bar.foos_attributes_changed?
+    assert bar.foos_changed?
   end
 
   test "changes reset by save" do

--- a/test/dummy/app/models/bar.rb
+++ b/test/dummy/app/models/bar.rb
@@ -1,8 +1,6 @@
 class Bar < ActiveRecord::Base
   include DirtyAssociations
 
-  attr_accessor :foos_attributes
-
   has_many :foos
   monitor_association_changes :foos
   accepts_nested_attributes_for :foos


### PR DESCRIPTION
The association is the only attribute we can be sure exists on the
model so I think it makes sense to give the association name to
the `attribute_will_change!` message. This gives clients of the
library a single way of checking whether some association has
changed regardless of whether it was changed by setting the assoc
itself, or the asssoc's ids or attributes (in case of
accepts_nested_attributes)
