### PR TITLE
Fix #7 for including blanks in ids.

### DIFF
--- a/lib/dirty_associations.rb
+++ b/lib/dirty_associations.rb
@@ -13,14 +13,19 @@ module DirtyAssociations
     #
     # The +association+ parameter should be a string or symbol representing the name of an association.
     def monitor_association_changes(association)
+      define_method "#{association}=" do |value|
+        attribute_will_change!(association.to_s) if _association_will_change?(association, value)
+        super(value)
+      end
+
       ids = "#{association.to_s.singularize}_ids"
 
-      [association, ids].each do |name|
-        define_method "#{name}=" do |value|
-          attribute_will_change!(association.to_s) unless send(name) == value
-          super(value)
-        end
+      define_method "#{ids}=" do |value|
+        attribute_will_change!(association.to_s) if _ids_will_change?(ids, value)
+        super(value)
+      end
 
+      [association, ids].each do |name|
         define_method "#{name}_change" do
           changes[name]
         end
@@ -34,5 +39,16 @@ module DirtyAssociations
         end
       end
     end
+  end
+
+  private
+
+  def _association_will_change?(association, value)
+    send(association) != value
+  end
+
+  def _ids_will_change?(ids, value)
+    value = Array(value).reject &:blank?
+    send(ids) != value
   end
 end

--- a/test/dirty_associations_test.rb
+++ b/test/dirty_associations_test.rb
@@ -30,6 +30,24 @@ class DirtyAssociationsTest < ActiveSupport::TestCase
     assert bar.foos_changed?
   end
 
+  test "setting has_many association ids works with non-array" do
+    foo = FactoryGirl.create(:foo)
+
+    refute bar.foos_changed?
+
+    bar.foo_ids = foo.id
+    assert_equal [ foo.id ], bar.foo_ids
+    assert bar.foos_changed?
+  end
+
+  test "setting has_many association ids ignores blanks" do
+    foos = bar.foos
+    bar.foo_ids += [ "", nil ]
+    assert_equal foos, bar.foos
+
+    refute bar.foos_changed?
+  end
+
   test "changes reset by save" do
     bar.foos = [ FactoryGirl.create(:foo) ]
     assert bar.foos_changed?


### PR DESCRIPTION
It turns out that ActiveRecord rejects blanks before setting the ids. (It also allows setting to a single id, which I added a test for too.) https://github.com/rails/rails/blob/b8302bcfdaec2a9e7658262d6feeb535c572922d/activerecord/lib/active_record/associations/collection_association.rb#L59
