### PR TITLE
Go back to monitoring the nested attributes setter, for now.

### DIFF
--- a/lib/dirty_associations.rb
+++ b/lib/dirty_associations.rb
@@ -25,6 +25,11 @@ module DirtyAssociations
         super(value)
       end
 
+      define_method "#{association}_attributes=" do |value|
+        attribute_will_change!(association.to_s)
+        super(value)
+      end
+
       [association, ids].each do |name|
         define_method "#{name}_change" do
           changes[name]

--- a/test/dirty_associations_test.rb
+++ b/test/dirty_associations_test.rb
@@ -48,6 +48,11 @@ class DirtyAssociationsTest < ActiveSupport::TestCase
     refute bar.foos_changed?
   end
 
+  test "setting has_many assocation attributes adds association to changes" do
+    bar.assign_attributes(:foos_attributes => [{}, {}])
+    assert bar.foos_changed?
+  end
+
   test "changes reset by save" do
     bar.foos = [ FactoryGirl.create(:foo) ]
     assert bar.foos_changed?


### PR DESCRIPTION
I'm working on a possibly better way to monitor association changes in the nested-attribute branch, but for now this restores the behavior we need to not break CM.
