### PR TITLE
Ignore changes if new value is just string version of old value

### DIFF
--- a/lib/dirty_associations.rb
+++ b/lib/dirty_associations.rb
@@ -54,7 +54,7 @@ module DirtyAssociations
 
   def _ids_will_change?(ids, value)
     value = Array(value).reject &:blank?
-    send(ids) != value
+    send(ids).map(&:to_s) != value.map(&:to_s)
   end
 
   def _nested_attributes_will_change?(attributes_collection)

--- a/test/dirty_associations_test.rb
+++ b/test/dirty_associations_test.rb
@@ -48,6 +48,14 @@ class DirtyAssociationsTest < ActiveSupport::TestCase
     refute bar.foos_changed?
   end
 
+  test "setting has_many association ids ignores change if it's only string version of existing" do
+    foos = bar.foos
+    bar.foo_ids = bar.foo_ids.map(&:to_s)
+    assert_equal foos, bar.foos
+
+    refute bar.foos_changed?
+  end
+
   test "setting has_many assocation attributes adds association to changes" do
     bar.assign_attributes(:foos_attributes => [{}, {}])
     assert bar.foos_changed?


### PR DESCRIPTION
@dougo @jmpage This should fix our bug where we're sending updates for no-ops.
